### PR TITLE
Add user and interview models with JPA annotations and validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,16 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+    		<groupId>org.springframework.boot</groupId>
+    		<artifactId>spring-boot-starter-validation</artifactId>
+    		<version>4.0.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/org/codeOn/InterviewHub/auth/model/Role.java
+++ b/src/main/java/org/codeOn/InterviewHub/auth/model/Role.java
@@ -1,0 +1,6 @@
+package org.codeOn.InterviewHub.auth.model;
+
+public enum Role {
+    RECRUITER,
+    INTERVIEWER
+}

--- a/src/main/java/org/codeOn/InterviewHub/auth/model/User.java
+++ b/src/main/java/org/codeOn/InterviewHub/auth/model/User.java
@@ -1,0 +1,53 @@
+package org.codeOn.InterviewHub.auth.model;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Email
+    @NotBlank 
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/codeOn/InterviewHub/interview/model/InterviewDrive.java
+++ b/src/main/java/org/codeOn/InterviewHub/interview/model/InterviewDrive.java
@@ -1,0 +1,62 @@
+package org.codeOn.InterviewHub.interview.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.codeOn.InterviewHub.auth.model.User;
+@Entity
+@Table(name = "interview_drives")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterviewDrive {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDate date;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "create_by", nullable = false)
+    private User createdBy;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/codeOn/InterviewHub/interview/model/InterviewRound.java
+++ b/src/main/java/org/codeOn/InterviewHub/interview/model/InterviewRound.java
@@ -1,0 +1,72 @@
+package org.codeOn.InterviewHub.interview.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "interview_rounds",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            columnNames = {"interview_drive_id", "sequence"}
+        )
+    }
+)
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class InterviewRound {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    @NotNull
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_drive_id", nullable = false)
+    private InterviewDrive interviewDrive;
+
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void createdAt(){
+        createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void updatedAt(){
+        updatedAt = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces the core domain entities for InterviewFlow using a modular monolith approach.

## Changes
- Added User and Role entities in the auth module
- Added InterviewDrive and InterviewRound entities in the interview module
- Defined relationships and audit fields
- Structured entities following modular boundaries

## Notes
- No business logic added
- No API changes
- Focused on clean domain modeling
